### PR TITLE
Updated the cors config to accept www.mathmlcloud.org as well

### DIFF
--- a/config/cors.js
+++ b/config/cors.js
@@ -47,7 +47,7 @@ module.exports.cors = {
   *                                                                          *
   ***************************************************************************/
 
-  origin: 'https://app.mathmlcloud.org,https://app-staging.mathmlcloud.org,https://staging.mathmlcloud.org,https://mathmlcloud.org,http://localhost:1337,http://localhost:4567',
+  origin: 'https://app.mathmlcloud.org,https://app-staging.mathmlcloud.org,https://staging.mathmlcloud.org,https://mathmlcloud.org,https://www.mathmlcloud.org,http://localhost:1337,http://localhost:4567',
   //origin: '*',
 
   /***************************************************************************


### PR DESCRIPTION
When trying to access www.mathmlcloud.org it seemed unable to connect. I updated the CORS config to allow access to the API from www.mathmlcloud.org. 